### PR TITLE
fix: Use host environment for git to get root path

### DIFF
--- a/kas/repos.py
+++ b/kas/repos.py
@@ -287,7 +287,7 @@ class Repo:
         """
         git_cmd = ['git', 'rev-parse', '--show-toplevel',
                    '--show-superproject-working-tree']
-        (ret, output) = run_cmd(git_cmd, cwd=path, fail=False)
+        (ret, output) = run_cmd(git_cmd, cwd=path, env=os.environ, fail=False)
         if ret == 0:
             return sorted(output.strip().split('\n'))[0]
 


### PR DESCRIPTION
Hi All,

A few years ago, Git introduced a safe directory policy that prevents Git commands from running, particularly in CI environments. This behavior breaks the `get_root_path` functionality because the command:
```
git rev-parse --show-toplevel --show-superproject-working-tree
```
returns the following error:
```
fatal: detected dubious ownership in repository at '/builds/taras.zaporozhets/yoyo'
To add an exception for this directory, call:
	git config --global --add safe.directory /builds/taras.zaporozhets/yoyo
```
This MR updates get_root_path to allow Git to use the host gitconfig, including the defined exception directory.

Best,
Taras


